### PR TITLE
Actions workflow setup

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,7 @@ name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "actions-workflow-setup" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,8 @@ jobs:
       
     - name: Test with pytest
       run: |
-        export SPOTIPY_CLIENT_ID = ${{ secrets.SPOTIPY_CLIENT_ID }}
-        export SPOTIPY_CLIENT_SECRET = ${{ secrets.SPOTIPY_CLIENT_SECRET }}
-        export SPOTIPY_REDIRECT_URI = ${{ secrets.SPOTIPY_REDIRECT_URI }}
         pytest
+      env: 
+        SPOTIPY_CLIENT_ID: ${{ secrets.SPOTIPY_CLIENT_ID }}
+        SPOTIPY_CLIENT_SECRET: ${{ secrets.SPOTIPY_CLIENT_SECRET }}
+        SPOTIPY_REDIRECT_URI: ${{ secrets.SPOTIPY_REDIRECT_URI }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,12 +34,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --ignore=C901,F821,F631 --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test env vars for python
-      run: python -c 'import os;print(os.environ)'
-      env: 
-        SPOTIPY_CLIENT_ID: ${{ secrets.SPOTIPY_CLIENT_ID }}
-        SPOTIPY_CLIENT_SECRET: ${{ secrets.SPOTIPY_CLIENT_SECRET }}
-        SPOTIPY_REDIRECT_URI: ${{ secrets.SPOTIPY_REDIRECT_URI }}
+      
     - name: Test with pytest
       run: |
+        export SPOTIPY_CLIENT_ID = ${{ secrets.SPOTIPY_CLIENT_ID }}
+        export SPOTIPY_CLIENT_SECRET = ${{ secrets.SPOTIPY_CLIENT_SECRET }}
+        export SPOTIPY_REDIRECT_URI = ${{ secrets.SPOTIPY_REDIRECT_URI }}
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,6 +34,12 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --ignore=C901,F821,F631 --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test env vars for python
+      run: python -c 'import os;print(os.environ)'
+      env: 
+        SPOTIPY_CLIENT_ID: ${{ secrets.SPOTIPY_CLIENT_ID }}
+        SPOTIPY_CLIENT_SECRET: ${{ secrets.SPOTIPY_CLIENT_SECRET }}
+        SPOTIPY_REDIRECT_URI: ${{ secrets.SPOTIPY_REDIRECT_URI }}
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,7 @@ jobs:
       
     - name: Test with pytest
       run: |
-        pytest
+        pytest --trace
       env: 
         SPOTIPY_CLIENT_ID: ${{ secrets.SPOTIPY_CLIENT_ID }}
         SPOTIPY_CLIENT_SECRET: ${{ secrets.SPOTIPY_CLIENT_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Configure GitHub Actions workflow to: 
1. Validate dependencies and requirements.txt
2. Lint with flake8 and ignore error codes: C901,F821,F631
4. Initiate and run pytest on existing test structures

Ran into the issue that running pytest with the `--trace` tag resulted in pytest hanging until Actions timeout, despite tests passing. 